### PR TITLE
Add commit information and image tag into an archive

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -290,7 +290,7 @@ def call(body) {
       }
 
       def result="commitID=${gitCommit}\\n" + 
-	         "commitMessage=${gitCommitMessage} \\n" + 
+	         "commitMessage=${gitCommitMessage}\\n" + 
 	         "registry=${registry}\\n" + 
 	         "image=${image}\\n" + 
 	         "imageTag=${imageTag}"


### PR DESCRIPTION
Example archive contents when checking out https://github.com/ibm-developer/icp-nodejs-sample as follows:

```
commitID=b317aa1
commitMessage=Specify exact folder name for chart

registry=mycluster.icp:8500/default/
image=ibm-nodejs-sample
imageTag=b317aa1
```

If there is no value (e.g. you're on minikube, the key will still be present `registry` but there'll be no value).

Admittedly I've only tested the case where all values are present, otherwise we're just going to be adding empty strings into buildData.txt. I have Go code in the Microclimate Devops component that parses this as keys and values so there is a dependency on what these keys need to be.

Ideally this will go into master and then 18.06 please!