### PR TITLE
If no deploy branch is set, assume straight-through deployment

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -298,7 +298,9 @@ def call(body) {
       sh "echo '${result}' > buildData.txt"
       archiveArtifacts 'buildData.txt'
 
-      if (deploy && env.BRANCH_NAME == getDeployBranch()) {
+      // No deploy branch, want to deploy? Go ahead (we're in a straight-through scenario)
+      // Or if there's a deploy branch set and we're on it, go ahead and deploy that.
+      if (deploy && (getDeployBranch() == "" || env.BRANCH_NAME == getDeployBranch())) {
         stage ('Deploy') {
           if (!helmInitialized) {
             initalizeHelm ()


### PR DESCRIPTION
This PR modifies the logic that checks whether we should go ahead and deploy a user's Helm chart or not, specifically enabling a straight-through deployment case whereby the user hasn't specified a deployment branch (in Microclimate they opt for the "Last successful commit" to be used instead).

**Why it works**
Microclimate creates a Jenkins multibranch project for each user created "Microclimate project". That results in `env.BRANCH_NAME` being present and set and its value is always what the current branch is for the Jenkins job.

The value of `env.BRANCH_NAME` is compared to the result of `getDeployBranch()` which returns the set `deployBranch` for a Microclimate project.

In the event of a straight-through deployment, we wish for this to be not set (so it'll be an empty string actually).

**Testing done**
Straight-through deployment emulated by invoking the Microclimate Devops API directly so the `deployBranch` is not provided (it is actually set though to be `""`: an empty string). This emulates what we want the Microclimate UI to be doing: setting the deploy branch (e.g. if not specified) to be `""` (an empty string). The deployment was built, pushed, tagged and deployed.

I then tested all behaviour is good (build, push, deploy) when a deploy branch is selected (the same check as we *currently* have before this PR is merged).

To be merged into master and 18.06 please, assuming all is well!