### PR TITLE
Add full commit ID, add to archive

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -114,9 +114,11 @@ def call(body) {
     node('msbPod') {
       def gitCommit
       def gitCommitMessage
+      def fullCommitID
 
       stage ('Extract') {
         checkout scm
+	fullCommitID = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
         gitCommit = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
 	gitCommitMessage = sh(script: 'git log --format=%B -n 1 ${gitCommit}', returnStdout: true)
         echo "checked out git commit ${gitCommit}"
@@ -290,6 +292,7 @@ def call(body) {
       }
 
       def result="commitID=${gitCommit}\\n" + 
+	         "fullCommit=${fullCommitID}\\n" +
 	         "commitMessage=${gitCommitMessage}\\n" + 
 	         "registry=${registry}\\n" + 
 	         "image=${image}\\n" + 


### PR DESCRIPTION
The full commit ID is required by Microclimate's Devops component, so retrieve it and store into a variable then archive it.

Artifact now looks like:

```
commitID=bff8178
fullCommit=bff8178e0e13e05e584c8a2e1a2eb48dfb72335e
commitMessage=Named branch


registry=
image=node
imageTag=bff8178
```