### PR TITLE
[WIP] Conditional archive (and sooner)

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -229,6 +229,11 @@ def call(body) {
 	  "imageTag=${imageTag}"
         sh "echo '${archiveContents}' > buildData.txt"
         archiveArtifacts 'buildData.txt'
+      } else {
+        // If we don't do this, the Jenkins job can be marked as a success even though the push failed!
+	// This is because we capture the return code in a variable, see
+	// https://stackoverflow.com/questions/42428871/jenkins-pipeline-bubble-up-the-shell-exit-code-to-fail-the-stage
+	error "Didn't docker push successfully so failing this Jenkins build"	
       }
 
       def realChartFolder = null

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -213,7 +213,17 @@ def call(body) {
             }
           }
         }
-      }
+      }	    
+
+      def result="commitID=${gitCommit}\\n" + 
+	         "fullCommit=${fullCommitID}\\n" +
+	         "commitMessage=${gitCommitMessage}\\n" + 
+	         "registry=${registry}\\n" + 
+	         "image=${image}\\n" + 
+	         "imageTag=${imageTag}"
+	    
+      sh "echo '${result}' > buildData.txt"
+      archiveArtifacts 'buildData.txt'
 
       def realChartFolder = null
       if (fileExists(chartFolder)) {
@@ -290,16 +300,6 @@ def call(body) {
           }
         }
       }
-
-      def result="commitID=${gitCommit}\\n" + 
-	         "fullCommit=${fullCommitID}\\n" +
-	         "commitMessage=${gitCommitMessage}\\n" + 
-	         "registry=${registry}\\n" + 
-	         "image=${image}\\n" + 
-	         "imageTag=${imageTag}"
-	    
-      sh "echo '${result}' > buildData.txt"
-      archiveArtifacts 'buildData.txt'
 
       if (deploy && env.BRANCH_NAME == getDeployBranch()) {
         stage ('Deploy') {

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -211,13 +211,15 @@ def call(body) {
               if (registry) {
                 sh "docker tag ${image}:${imageTag} ${registry}${image}:${imageTag}"
                 dockerPushed = sh(returnStatus: true, script: "docker push ${registry}${image}:${imageTag}")
+		print "Status code from Docker push: ${dockerPushed}"
               }
             }
           }
         }
       }	    
 
-      if (dockerPushed) {
+      // 0 for true: we got the return code and a straight if (dockerPushed) doesn't evaluate to true
+      if (dockerPushed == 0) {
 	print "Pushed the built image to the Docker registry successfully, creating the artifact"
         def archiveContents="commitID=${gitCommit}\\n" + 
           "fullCommit=${fullCommitID}\\n" +


### PR DESCRIPTION
This PR does two things.

- Sooner (e.g. *before* the deploy and test steps), do the archiving only if the preceding Docker push succeeded
- If the Docker push fails, fail the build (required as when capturing the variable into stdout, the Jenkins pipeline step will not automatically fail).

Manual tests done using Jenkins builds with Microclimate: ensuring the Microclimate builds API returns correct results and that archives are produced only when the Docker push succeeds. Else, no archive, build errors out with a useful message.

**I'm testing the mvn verify behaviour currently, we want it to archive the build data before this step (so immediately after the docker build and push**.