### PR TITLE
Archive build info (including short and full commit IDs)

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -109,10 +109,14 @@ def call(body) {
   ) {
     node('msbPod') {
       def gitCommit
+      def gitCommitMessage
+      def fullCommitID
 
       stage ('Extract') {
         checkout scm
         gitCommit = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
+        fullCommitID = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
+        gitCommitMessage = sh(script: 'git log --format=%B -n 1 ${gitCommit}', returnStdout: true)
         echo "checked out git commit ${gitCommit}"
       }
 
@@ -273,6 +277,16 @@ def call(body) {
           }
         }
       }
+      
+      def result="commitID=${gitCommit}\\n" + 
+	         "fullCommit=${fullCommitID}\\n" +
+	         "commitMessage=${gitCommitMessage}\\n" + 
+	         "registry=${registry}\\n" + 
+	         "image=${image}\\n" + 
+	         "imageTag=${imageTag}"
+	    
+      sh "echo '${result}' > buildData.txt"
+      archiveArtifacts 'buildData.txt'
 
       if (deploy && env.BRANCH_NAME == getDeployBranch()) {
         stage ('Deploy') {


### PR DESCRIPTION
Emulates the current 18.06 branch's behaviour.

Tested Microclimate's Devops API for builds picks up this info fine when this library is used (I modified my Helm chart install of Microclimate to use this version of the library).

Example output:

```
commitID=8becb01
fullCommit=8becb0192efe0156bf16735faab7ee0a52855111
commitMessage=Merge pull request #1 from dibbles/master

Modify chart to allow two deployments in one namespace for one project

registry=mycluster.icp:8500/default/
image=node
imageTag=8becb01
```