### PR TITLE
Use new notifications endpoint to deploy

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -337,7 +337,7 @@ def notifyDevops (String gitCommit, String fullCommitID, String image,
 
     print "gitCommit=${gitCommit}, fullCommitID=${fullCommitID}, image: ${image} \
       imageTag=${imageTag}, branchName=${branchName}, triggerType=${triggerType} \
-      clusterConfigSecret=${clusterConfigSecret}, status=${status}, buildNumber=${buildNumber}"
+      buildNumber=${buildNumber}"
 
     def notificationData = [
       chart: [gitCommit: gitCommit, fullCommit: fullCommitID],

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -87,9 +87,6 @@ def call(body) {
   def projectNamespace = jobNameSplit[0]
   def projectName = jobNameSplit[1]
   def branchName = jobNameSplit[2]
-	
-  def buildNumber = (env.BUILD_NUMBER).toInteger()
-  print "Thinking your build number is ${buildNumber}"
 
   // We won't be able to get hold of registrySecret if Jenkins is running in a non-default namespace that is not the deployment namespace.
   // In that case we'll need the registrySecret to have been ported over, perhaps during pipeline install.

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -129,11 +129,12 @@ def call(body) {
       devopsHost = sh(script: "echo \$${mcReleaseName}_IBM_MICROCLIMATE_DEVOPS_SERVICE_HOST", returnStdout: true).trim()	       
       devopsPort = sh(script: "echo \$${mcReleaseName}_IBM_MICROCLIMATE_DEVOPS_SERVICE_PORT", returnStdout: true).trim()	      
       devopsEndpoint = "https://${devopsHost}:${devopsPort}"
+
       stage ('Extract') {
         checkout scm
-	      fullCommitID = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
+	fullCommitID = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
         gitCommit = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
-	      gitCommitMessage = sh(script: 'git log --format=%B -n 1 ${gitCommit}', returnStdout: true)
+	gitCommitMessage = sh(script: 'git log --format=%B -n 1 ${gitCommit}', returnStdout: true)
         echo "checked out git commit ${gitCommit}"
       }
 

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -321,22 +321,21 @@ def call(body) {
           helmInitialized = true
         }
         notifyDevops(gitCommit, fullCommitID, image, imageTag, 
-          branchName, "build", "", projectName, projectNamespace, "", "", env.BUILD_NUMBER.toInteger())
+          branchName, "build", projectName, projectNamespace, env.BUILD_NUMBER.toInteger())
       }
     }
   }
 }
 
 def notifyDevops (String gitCommit, String fullCommitID, String image, 
-  String imageTag, String branchName, String triggerType, 
-  String clusterConfigSecret, String projectName, String projectNamespace, String targetNamespace, String status, Integer buildNumber) {
+  String imageTag, String branchName, String triggerType, String projectName, String projectNamespace, Integer buildNumber) {
 	
   notificationEndpoint="${devopsEndpoint}/v1/namespaces/${projectNamespace}/projects/${projectName}/notifications"	
 	
   stage ('Notify Devops') {	  
     print "Poking the notification API at ${notificationEndpoint}, parameters..."	
 
-    print "gitCommit: ${gitCommit}, fullCommitID: ${fullCommitID}, image: ${image} \
+    print "gitCommit=${gitCommit}, fullCommitID=${fullCommitID}, image: ${image} \
       imageTag=${imageTag}, branchName=${branchName}, triggerType=${triggerType} \
       clusterConfigSecret=${clusterConfigSecret}, status=${status}, buildNumber=${buildNumber}"
 
@@ -344,9 +343,9 @@ def notifyDevops (String gitCommit, String fullCommitID, String image,
       chart: [gitCommit: gitCommit, fullCommit: fullCommitID],
       overrides: [image: [repository: image, tag: imageTag]],
       trigger: [type: triggerType, branch: branchName],
-      clusterConfigSecret: clusterConfigSecret,
-      namespace: targetNamespace,
-      status: status,
+      clusterConfigSecret: "",
+      namespace: "",
+      status: "",
       buildNumber: buildNumber
     ]
 


### PR DESCRIPTION
This relies on changes to the Devops component for Microclimate and should go into both master and then into a new 18.07 branch please.

Instead of using "find me the deploy branch" for a project logic, we instead send a http request to the Devops notification endpoint, passing in sufficient information such that Devops can create a release. Note the trigger type being set to build and the commit ID being passed in, thus allowing us to have "straight through releases" as part of Devops update controller functionality that this relies upon.

The Devops endpoint is programatically determined.