### PR TITLE
Delete test namespace *after* Helm deletion for the release in it

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -287,7 +287,6 @@ def call(body) {
               step([$class: 'ArtifactArchiver', artifacts: '**/target/failsafe-reports/*.txt', allowEmptyArchive: true])
               if (!debug) {
                 container ('kubectl') {
-                  sh "kubectl delete namespace ${testNamespace}"
                   if (fileExists(realChartFolder)) {
                     container ('helm') {
                       def deleteCommand = "helm delete ${tempHelmRelease} --purge"
@@ -298,7 +297,10 @@ def call(body) {
 		      sh deleteCommand
                     }
                   }
-                }
+		  // Intentionally do this as the final step in here so we can actually delete it
+                  // A namespace will not be removed if there's a Kube resource still active in there
+                  sh "kubectl delete namespace ${testNamespace}"
+                }                
               }
             }
           }


### PR DESCRIPTION
We have observed "testns" namespaces remaining in our test runs with Travis when testing Microclimate, and I've observed that deleting a namespace with kubectl won't complete while there are still resources running inside of it. Because of this we should delete the release in the test namespace prior to attempting to delete the namespace.

As this a functional fix, once we like this I'm inclined to create PRs for all of our "service branches".

Testing done with ICP 2.1.0.3, Microclimate master version of the chart, and https://github.com/microclimate-demo/microprofile.git which is used by the Microclimate Helm chart tests.

I see no "testns" namespaces afterwards.