### PR TITLE
Allow the use of extra Git config options

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -60,6 +60,7 @@ def call(body) {
   def userSpecifiedChartFolder = config.chartFolder
   def chartFolder = userSpecifiedChartFolder ?: ((env.CHART_FOLDER ?: "").trim() ?: 'chart')
   def libertyLicenseJarName = config.libertyLicenseJarName ?: (env.LIBERTY_LICENSE_JAR_NAME ?: "").trim()
+  def extraGitOptions = config.gitOptions ?: (env.EXTRA_GIT_OPTIONS ?: "").trim()
 
   // Internal 
   def registry = (env.REGISTRY ?: "").trim()
@@ -137,6 +138,11 @@ def call(body) {
       devopsEndpoint = "https://${devopsHost}:${devopsPort}"
 
       stage ('Extract') {
+	  // E.g. may wish to add http.sslVerify false when working with one's own SCM that has self-signed certs
+	  if (extraGitOptions) {
+	    echo "Extra git options found, setting global Git options to include ${extraGitOptions}"
+	    configSet = sh(script: 'git config --global ${extraGitOptions}')
+          }
 	  checkout scm
 	  fullCommitID = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
 	  gitCommit = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -140,7 +140,7 @@ def call(body) {
       stage ('Extract') {
 	  // E.g. may wish to add http.sslVerify false when working with one's own SCM that has self-signed certs
 	  if (extraGitOptions) {
-	    echo "Extra git options found, setting global Git options to include ${extraGitOptions}"
+	    echo "Extra Git options found, setting global Git options to include ${extraGitOptions}"
 	    configSet = sh(script: 'git config ${extraGitOptions}', returnStdout: true)
           }
 	  checkout scm

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -141,7 +141,7 @@ def call(body) {
 	  // E.g. may wish to add http.sslVerify false when working with one's own SCM that has self-signed certs
 	  if (extraGitOptions) {
 	    echo "Extra Git options found, setting global Git options to include ${extraGitOptions}"
-	    configSet = sh(script: 'git config ${extraGitOptions}', returnStdout: true)
+	    configSet = sh(script: "git config ${extraGitOptions}", returnStdout: true)
           }
 	  checkout scm
 	  fullCommitID = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -15,12 +15,16 @@
     image = no default value - image name must be specified in your Jenkinsfile
     build = 'true' - any value other than 'true' == false
     deploy = 'true' - any value other than 'true' == false
+    
 
     Maven projects only:
     mvnCommands = 'package' - builds project by default, other Maven commands can be specified
     test = 'true' - 'mvn verify' is run if this value is 'true' and a pom.xml exists
     debug = 'false' - resources created during tests are deleted unless this value is set to 'true'
-    chartFolder = 'chart' - chart folder to be used for testing only 
+    chartFolder = 'chart' - chart folder to be used for testing only
+    gitOptions = '' - any extra Git options to be provided when cloning the source to build, 
+    for example you may wish to provide --global http.sslVerify false to permit self-signed certificates, 
+    such as if you're hosting your own source code management system
 
     libertyLicenseJarName = '' -  Liberty license jar name to use 
 

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -141,7 +141,7 @@ def call(body) {
 	  // E.g. may wish to add http.sslVerify false when working with one's own SCM that has self-signed certs
 	  if (extraGitOptions) {
 	    echo "Extra git options found, setting global Git options to include ${extraGitOptions}"
-	    configSet = sh(script: 'git config --global ${extraGitOptions}')
+	    configSet = sh(script: 'git config ${extraGitOptions}')
           }
 	  checkout scm
 	  fullCommitID = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -142,7 +142,6 @@ def call(body) {
       devopsEndpoint = "https://${devopsHost}:${devopsPort}"
 
       stage ('Extract') {
-	  // E.g. may wish to add http.sslVerify false when working with one's own SCM that has self-signed certs
 	  if (extraGitOptions) {
 	    echo "Extra Git options found, setting global Git options to include ${extraGitOptions}"
 	    configSet = sh(script: "git config ${extraGitOptions}", returnStdout: true)

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -141,7 +141,7 @@ def call(body) {
 	  // E.g. may wish to add http.sslVerify false when working with one's own SCM that has self-signed certs
 	  if (extraGitOptions) {
 	    echo "Extra git options found, setting global Git options to include ${extraGitOptions}"
-	    configSet = sh(script: 'git config ${extraGitOptions}')
+	    configSet = sh(script: 'git config ${extraGitOptions}', returnStdout: true)
           }
 	  checkout scm
 	  fullCommitID = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -142,7 +142,7 @@ def call(body) {
 	  if (extraGitOptions) {
 	    echo "Extra Git options found, setting global Git options to include ${extraGitOptions}"
 	    configSet = sh(script: "git config ${extraGitOptions}", returnStdout: true)
-          }
+	  }
 	  checkout scm
 	  fullCommitID = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
 	  gitCommit = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -15,19 +15,16 @@
     image = no default value - image name must be specified in your Jenkinsfile
     build = 'true' - any value other than 'true' == false
     deploy = 'true' - any value other than 'true' == false
-    
+    gitOptions = '' - any Git config options to use, for example you may wish to provide 
+      --global http.sslVerify false to permit self-signed certificates if you're hosting your own SCM
 
     Maven projects only:
     mvnCommands = 'package' - builds project by default, other Maven commands can be specified
     test = 'true' - 'mvn verify' is run if this value is 'true' and a pom.xml exists
     debug = 'false' - resources created during tests are deleted unless this value is set to 'true'
     chartFolder = 'chart' - chart folder to be used for testing only
-    gitOptions = '' - any extra Git options to be provided when cloning the source to build, 
-    for example you may wish to provide --global http.sslVerify false to permit self-signed certificates, 
-    such as if you're hosting your own source code management system
 
     libertyLicenseJarName = '' -  Liberty license jar name to use 
-
 
   These are the names of images to be downloaded from https://hub.docker.com/.
 
@@ -143,7 +140,7 @@ def call(body) {
 
       stage ('Extract') {
 	  if (extraGitOptions) {
-	    echo "Extra Git options found, setting global Git options to include ${extraGitOptions}"
+	    echo "Extra Git options found, setting Git config options to include ${extraGitOptions}"
 	    configSet = sh(script: "git config ${extraGitOptions}", returnStdout: true)
 	  }
 	  checkout scm


### PR DESCRIPTION
Can be achieved by either modifying one's Jenkinsfile, or passed in by use of an environment variable that can be exposed through a Microclimate Helm chart change.

Tested with Jenkins builds when this variable is both not set, when its value is an empty string and when set. 

Admittedly I don't have access to my own GitLab with self-signed certs in order to test the suggested config option, but this PR does allow folks to at least configure Git options for their own needs.

When it is set to "--global http.sslVerify false", I get:

```
Extra Git options found, setting Git config options to include --global http.sslVerify false
[Pipeline] sh
[myns_muhpipeline_master-4XLH5FP5MJOBS3CBVVFASI3QMCZIC54DSQUVX2SO6Q26VGJHB3ZA] Running shell script
+ git config --global http.sslVerify false
[Pipeline] checkout
Cloning the remote Git repository
Cloning with configured refspecs honoured and without tags
Cloning repository https://github.com/microclimate-dev2ops/slim-devops-test-project.git
```