### PR TITLE
Delete the test namespace (unless debug is on)

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -254,6 +254,8 @@ def call(body) {
       }
 
       def realChartFolder = null
+      def testsAttempted = false
+	    
       if (fileExists(chartFolder)) {
         // find the likely chartFolder location
         realChartFolder = getChartFolder(userSpecifiedChartFolder, chartFolder)
@@ -371,9 +373,13 @@ def call(body) {
       archiveArtifacts 'buildData.txt'
       // tests are enabled and yet something went wrong (e.g. didn't deploy the test release, or tests failed)? Fail the build
       
-      echo "Test is " + test
-      if (test) {
-        if (verifyAttempt != 0) {
+      echo "Test is " + test + ", tests attempted: " + testsAttempted
+	    
+      // Pipelines are created with test = true as a default from the Microclimate Helm chart.
+      // If tests were attempted, and then a problem happened (tests failed, or it didn't deploy, fail the build.
+      // testsAttempted is set when we enter our testing block: which currently only supports Maven projects.
+      if (testsAttempted) {
+        if (verifyAttempt != 0) || (testDeployAttempt == 0) {
           def message = "Marking the build as a failed one: test was set to true " +
             "and a non-zero return code was returned when running the verify stage in this pipeline. " +
             "This indicates there are test failures to investigate or the test release did not deploy. No further pipeline code will be run."

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -379,7 +379,7 @@ def call(body) {
       // If tests were attempted, and then a problem happened (tests failed, or it didn't deploy, fail the build.
       // testsAttempted is set when we enter our testing block: which currently only supports Maven projects.
       if (testsAttempted) {
-        if (verifyAttempt != 0) || (testDeployAttempt == 0) {
+        if (verifyAttempt != 0 || testDeployAttempt == 0) {
           def message = "Marking the build as a failed one: test was set to true " +
             "and a non-zero return code was returned when running the verify stage in this pipeline. " +
             "This indicates there are test failures to investigate or the test release did not deploy. No further pipeline code will be run."
@@ -392,7 +392,7 @@ def call(body) {
           initalizeHelm ()
           helmInitialized = true
         }
-	      echo "Notifying Devops"
+	echo "Notifying Devops"
         notifyDevops(gitCommit, fullCommitID, registry + image, imageTag, 
           branchName, "build", projectName, projectNamespace, env.BUILD_NUMBER.toInteger())
       }

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -380,10 +380,12 @@ def call(body) {
       }
 
       if (deploy) {
+        echo "Deploy is true"
         if (!helmInitialized) {
           initalizeHelm ()
           helmInitialized = true
         }
+	      echo "Notifying Devops"
         notifyDevops(gitCommit, fullCommitID, registry + image, imageTag, 
           branchName, "build", projectName, projectNamespace, env.BUILD_NUMBER.toInteger())
       }

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -379,6 +379,9 @@ def call(body) {
       // If tests were attempted, and then a problem happened (tests failed, or it didn't deploy, fail the build.
       // testsAttempted is set when we enter our testing block: which currently only supports Maven projects.
       if (testsAttempted) {
+	      echo "Result of verification is " + verifyAttempt
+	      echo "Result of the test deploy attempt is: " + testDeployAttempt
+	      echo "If either of these values are not 0, we will fail the build"
         if (verifyAttempt != 0 || testDeployAttempt != 0) {
           def message = "Marking the build as a failed one: test was set to true " +
             "and a non-zero return code was returned when running the verify stage in this pipeline. " +
@@ -392,7 +395,7 @@ def call(body) {
           initalizeHelm ()
           helmInitialized = true
         }
-	echo "Notifying Devops"
+	      echo "Notifying Devops"
         notifyDevops(gitCommit, fullCommitID, registry + image, imageTag, 
           branchName, "build", projectName, projectNamespace, env.BUILD_NUMBER.toInteger())
       }

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -266,7 +266,7 @@ def call(body) {
       }
 
       if (test && fileExists('pom.xml') && realChartFolder != null && fileExists(realChartFolder)) {
-        stage ('Verify') 
+        stage ('Verify') {
 	        testsAttempted = true
           testNamespace = "testns-${env.BUILD_ID}-" + UUID.randomUUID()
           echo "testing against namespace " + testNamespace
@@ -275,7 +275,7 @@ def call(body) {
           while (tempHelmRelease.endsWith('-') || tempHelmRelease.length() > 53) tempHelmRelease = tempHelmRelease.substring(0,tempHelmRelease.length()-1)
   
           container ('kubectl') {
-          def testNSCreationAttempt = sh(returnStatus: true, script: "kubectl create namespace ${testNamespace} > ns_creation_attempt.txt")
+            def testNSCreationAttempt = sh(returnStatus: true, script: "kubectl create namespace ${testNamespace} > ns_creation_attempt.txt")
             if (testNSCreationAttempt != 0) {
               echo "Warning, did not create the test namespace successfully, error code is: ${testNSCreationAttempt}"		
             }

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -374,7 +374,7 @@ def call(body) {
         if (verifyAttempt != 0) {
           def message = "Marking the build as a failed one: test was set to true " +
             "and a non-zero return code was returned when running the verify stage in this pipeline. " +
-            "Likely indicates there are test failures to investigate: no further pipeline code will be run."
+            "This indicates there are test failures to investigate or the test release did not deploy. No further pipeline code will be run."
             error(message) // this fails the build with an error
         }
       }

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -266,7 +266,8 @@ def call(body) {
       }
 
       if (test && fileExists('pom.xml') && realChartFolder != null && fileExists(realChartFolder)) {
-        stage ('Verify') {
+        stage ('Verify') 
+	        testsAttempted = true
           testNamespace = "testns-${env.BUILD_ID}-" + UUID.randomUUID()
           echo "testing against namespace " + testNamespace
           String tempHelmRelease = (image + "-" + testNamespace)
@@ -309,7 +310,7 @@ def call(body) {
               echo "Warning, did not deploy the test release into the test namespace successfully, error code is: ${testDeployAttempt}" 
               echo "This build will be marked as a failure: halting after the deletion of the test namespace."
             }
-            printFromFile("deploy_attempt.txt")	  
+            printFromFile("deploy_attempt.txt")
           }
 
           container ('maven') {
@@ -320,8 +321,7 @@ def call(body) {
                 if (mavenSettingsConfigMap) {
                   mvnCommand += " --settings /msb_mvn_cfg/settings.xml"
                 }
-                mvnCommand += " verify"
-		testsAttempted = true
+                mvnCommand += " verify"		  
                 verifyAttempt = sh(script: "${mvnCommand} > verify_attempt.txt", returnStatus: true)
                 if (verifyAttempt != 0) {
                   echo "Warning, did not run ${mvnCommand} successfully, error code is: ${verifyAttempt}"		
@@ -375,7 +375,6 @@ def call(body) {
       // tests are enabled and yet something went wrong (e.g. didn't deploy the test release, or tests failed)? Fail the build
       
       echo "Test is " + test + ", tests attempted: " + testsAttempted
-	    
       // Pipelines are created with test = true as a default from the Microclimate Helm chart.
       // If tests were attempted, and then a problem happened (tests failed, or it didn't deploy, fail the build.
       // testsAttempted is set when we enter our testing block: which currently only supports Maven projects.

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -378,9 +378,8 @@ def call(body) {
             error(message) // this fails the build with an error
         }
       }
-
+      echo "Deploy is " + deploy
       if (deploy) {
-        echo "Deploy is true"
         if (!helmInitialized) {
           initalizeHelm ()
           helmInitialized = true

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -370,6 +370,8 @@ def call(body) {
       sh "echo '${result}' > buildData.txt"
       archiveArtifacts 'buildData.txt'
       // tests are enabled and yet something went wrong (e.g. didn't deploy the test release, or tests failed)? Fail the build
+      
+      echo "Test is " + test
       if (test) {
         if (verifyAttempt != 0) {
           def message = "Marking the build as a failed one: test was set to true " +

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -382,6 +382,7 @@ def call(body) {
 	      echo "Result of verification is " + verifyAttempt
 	      echo "Result of the test deploy attempt is: " + testDeployAttempt
 	      echo "If either of these values are not 0, we will fail the build"
+	      
         if (verifyAttempt != 0 || testDeployAttempt != 0) {
           def message = "Marking the build as a failed one: test was set to true " +
             "and a non-zero return code was returned when running the verify stage in this pipeline. " +

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -379,7 +379,7 @@ def call(body) {
       // If tests were attempted, and then a problem happened (tests failed, or it didn't deploy, fail the build.
       // testsAttempted is set when we enter our testing block: which currently only supports Maven projects.
       if (testsAttempted) {
-        if (verifyAttempt != 0 || testDeployAttempt == 0) {
+        if (verifyAttempt != 0 || testDeployAttempt != 0) {
           def message = "Marking the build as a failed one: test was set to true " +
             "and a non-zero return code was returned when running the verify stage in this pipeline. " +
             "This indicates there are test failures to investigate or the test release did not deploy. No further pipeline code will be run."

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -94,7 +94,9 @@ def call(body) {
   def projectNamespace = jobNameSplit[0]
   def projectName = jobNameSplit[1]
   def branchName = jobNameSplit[2]
-
+  def testDeployAttempt = 1 // declare here as we'll use again later: don't run tests if it didn't deploy
+  def verifyAttempt = 1 // we'll need this variable later too: fail the build if we didn't deploy the test release, or tests failed
+		
   // We won't be able to get hold of registrySecret if Jenkins is running in a non-default namespace that is not the deployment namespace.
   // In that case we'll need the registrySecret to have been ported over, perhaps during pipeline install.
 
@@ -264,13 +266,22 @@ def call(body) {
       if (test && fileExists('pom.xml') && realChartFolder != null && fileExists(realChartFolder)) {
         stage ('Verify') {
           testNamespace = "testns-${env.BUILD_ID}-" + UUID.randomUUID()
-          print "testing against namespace " + testNamespace
+          echo "testing against namespace " + testNamespace
           String tempHelmRelease = (image + "-" + testNamespace)
           // Name cannot end in '-' or be longer than 53 chars
           while (tempHelmRelease.endsWith('-') || tempHelmRelease.length() > 53) tempHelmRelease = tempHelmRelease.substring(0,tempHelmRelease.length()-1)
           container ('kubectl') {
-            sh "kubectl create namespace ${testNamespace}"
-            sh "kubectl label namespace ${testNamespace} test=true"
+	    def testNSCreationAttempt = sh(returnStatus: true, script: "kubectl create namespace ${testNamespace} > ns_creation_attempt.txt")
+            if (testNSCreationAttempt != 0) {
+		echo "Warning, did not create the test namespace successfully, error code is: ${testNSCreationAttempt}"		
+	    }
+	    printFromFile("ns_creation_attempt.txt")
+	    def testNSLabelAttempt = sh(returnStatus: true, script: "kubectl label namespace ${testNamespace} test=true > label_attempt.txt")
+	    if (testNSLabelAttempt != 0) {
+	      echo "Warning, did not label the test namespace ${testNamespace} successfully, error code is: ${testNSLabelAttempt}" 
+	    }
+	    printFromFile("label_attempt.txt")
+		
             if (registrySecret) {
               giveRegistryAccessToNamespace (testNamespace, registrySecret)
             }
@@ -279,28 +290,46 @@ def call(body) {
           if (!helmInitialized) {
             initalizeHelm ()
             helmInitialized = true
-          }
-          
+          }		
+	
           container ('helm') {
+            echo "Attempting to deploy the test release"
             def deployCommand = "helm install ${realChartFolder} --wait --set test=true --values pipeline.yaml --namespace ${testNamespace} --name ${tempHelmRelease}"
             if (fileExists("chart/overrides.yaml")) {
               deployCommand += " --values chart/overrides.yaml"
             }
             if (helmSecret) {
-              echo "adding --tls"
+              echo "Adding --tls to your deploy command"
               deployCommand += helmTlsOptions
             }
-            sh deployCommand
+	    testDeployAttempt = sh(script: "${deployCommand} > deploy_attempt.txt", returnStatus: true)
+	    if (testDeployAttempt != 0) {
+	      echo "Warning, did not deploy the test release into the test namespace successfully, error code is: ${testDeployAttempt}" 
+	      echo "This build will be marked as a failure: halting after the deletion of the test namespace."
+	    }
+	    printFromFile("deploy_attempt.txt")	  
           }
 
           container ('maven') {
             try {
-              def mvnCommand = "mvn -B -Dnamespace.use.existing=${testNamespace} -Denv.init.enabled=false"
-              if (mavenSettingsConfigMap) {
-                mvnCommand += " --settings /msb_mvn_cfg/settings.xml"
-              }
-              mvnCommand += " verify"
-              sh mvnCommand
+		    
+	      // We have a test release that we can run our Maven tests on	    
+	      if (testDeployAttempt == 0) {
+                def mvnCommand = "mvn -B -Dnamespace.use.existing=${testNamespace} -Denv.init.enabled=false"
+                if (mavenSettingsConfigMap) {
+                  mvnCommand += " --settings /msb_mvn_cfg/settings.xml"
+                }
+                mvnCommand += " verify"
+		    
+	        verifyAttempt = sh(script: "${mvnCommand} > verify_attempt.txt", returnStatus: true)
+	        if (verifyAttempt != 0) {
+	          echo "Warning, did not run ${mvnCommand} successfully, error code is: ${verifyAttempt}"		
+	        }
+	        printFromFile("verify_attempt.txt")    
+	      } else {
+	        echo "Not running tests as we detected that your test release failed to deploy"      
+	      }
+		    
             } finally {
               step([$class: 'JUnitResultArchiver', allowEmptyResults: true, testResults: '**/target/failsafe-reports/*.xml'])
               step([$class: 'ArtifactArchiver', artifacts: '**/target/failsafe-reports/*.txt', allowEmptyArchive: true])
@@ -313,12 +342,21 @@ def call(body) {
                         echo "adding --tls"
                         deleteCommand += helmTlsOptions
                       }
-                      sh deleteCommand
+		      // Until this is done, we can't get both stdout and the status code... https://issues.jenkins-ci.org/browse/JENKINS-44930?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&showAll=true
+		      def deletionAttempt = sh(script: "$deleteCommand > delete_test_release_attempt.txt", returnStatus: true)
+		      if (deletionAttempt != 0) {
+		        echo "Did not delete the test Helm release, error code from ${deleteCommand} is: ${deletionAttempt}" 
+		      }
+		      printFromFile("delete_test_release_attempt.txt")
                     }
                   }
 		  // Intentionally do this as the final step in here so we can actually delete it
                   // A namespace will not be removed if there's a Kube resource still active in there
-                  sh "kubectl delete namespace ${testNamespace}"
+                  def testNSDeletionAttempt = sh(script: "kubectl delete namespace ${testNamespace} > delete_test_namespace_attempt.txt", returnStatus: true)
+		  if (testNSDeletionAttempt != 0) {
+	            echo "Did not delete the test namespace ${testNamespace} successfully, error code is: ${testNSDeletionAttempt}" 
+	          }
+		  printFromFile("delete_test_namespace_attempt.txt")
                 }                
               }
             }
@@ -335,6 +373,16 @@ def call(body) {
       
       sh "echo '${result}' > buildData.txt"
       archiveArtifacts 'buildData.txt'
+	    
+      // tests are enabled and yet something went wrong (e.g. didn't deploy the test release, or tests failed)? Fail the build
+      if (test) {
+        if (verifyAttempt != 0) {
+	  def message = "Marking the build as a failed one: test was set to true " +
+	    "and a non-zero return code was returned when running the verify stage in this pipeline. " +
+	     "Likely indicates there are test failures to investigate: no further pipeline code will be run."
+	  error(message) // this fails the build with an error
+	}
+      }
 
       if (deploy) {
         if (!helmInitialized) {
@@ -346,6 +394,11 @@ def call(body) {
       }
     }
   }
+}
+
+def printFromFile(String fileName) {
+  def output = readFile(fileName).trim()
+  echo output
 }
 
 def notifyDevops (String gitCommit, String fullCommitID, String image, 

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -321,6 +321,7 @@ def call(body) {
                   mvnCommand += " --settings /msb_mvn_cfg/settings.xml"
                 }
                 mvnCommand += " verify"
+		testsAttempted = true
                 verifyAttempt = sh(script: "${mvnCommand} > verify_attempt.txt", returnStatus: true)
                 if (verifyAttempt != 0) {
                   echo "Warning, did not run ${mvnCommand} successfully, error code is: ${verifyAttempt}"		


### PR DESCRIPTION
Capture the exit codes of sh commands so the pipeline doesn't fail prematurely. As we can't capture stdout and status at once, log the resulting command to file and then print that always (so we don't totally consume the output for nobody to see).

In the case where the test release didn't deploy successfully, or the tests failed, fail the build manually (because we capture the status, this would not happen automatically). Regardless, delete the test namespace.

I've also converted every tab to spaces (it was inconsistent throughout, which is why you will be seeing whitespace changes).

For convenience, I've attached example Jenkins logs for when a project fails to deploy, and when the project does deploy and tests pass. 

We can clearly see the test namespace is deleted OK.

[deletionontestreleasefail.txt](https://github.com/microclimate-dev2ops/jenkins-library/files/2538914/deletionontestreleasefail.txt)
[successontests.txt](https://github.com/microclimate-dev2ops/jenkins-library/files/2538915/successontests.txt)

I also tested this with debug on, the test namespace lingers around and so does the release. Tested with Java projects with tests and Node.js projects without.

I also tested with an intentional test failure (and the build correctly is marked as a failure).

Please squash before merging