### PR TITLE
Various changes to reduce build times

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -441,10 +441,8 @@ def call(body) {
 }
 
 def printTime(String message) {
-  println "Timing..."
-  println message
-  println ""
-  println new Date().format("ddMMyy.HHmm", TimeZone.getTimeZone('Europe/Amsterdam'))
+  time = new Date().format("ddMMyy.HHmm", TimeZone.getTimeZone('Europe/Amsterdam'))
+  println "Timing, $message: $date"
 }
 
 def printFromFile(String fileName) {

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -88,6 +88,8 @@ def call(body) {
   mavenSettingsConfigMap=${mavenSettingsConfigMap} alwaysPullImage=${alwaysPullImage} helmTlsOptions=${helmTlsOptions} \
   maven=${maven} docker=${docker} kubectl=${kubectl} helm=${helm}" 
   
+  printTime("In the pipeline")
+
   def jobName = (env.JOB_BASE_NAME)
   // E.g. JOB_NAME=default/myproject/master
   def jobNameSplit = env.JOB_NAME.split("/")	
@@ -130,6 +132,7 @@ def call(body) {
     volumes: volumes
   ) {
     node('microclimatePod') {
+      printTime("In the node microclimatePod code")
       def gitCommit
       def previousCommit
       def gitCommitMessage
@@ -141,11 +144,15 @@ def call(body) {
       devopsEndpoint = "https://${devopsHost}:${devopsPort}"
 
       stage ('Extract') {
+	printTime("In the extract stage")
         if (extraGitOptions) {
           echo "Extra Git options found, setting Git config options to include ${extraGitOptions}"
           configSet = sh(script: "git config ${extraGitOptions}", returnStdout: true)
         }
         checkout scm
+
+	printTime("checkout scm done")
+
         fullCommitID = sh(script: 'git rev-parse HEAD', returnStdout: true).trim()
         gitCommit = sh(script: 'git rev-parse --short HEAD', returnStdout: true).trim()
         previousCommitStatus = sh(script: 'git rev-parse -q --short HEAD~1', returnStatus: true)      
@@ -167,12 +174,14 @@ def call(body) {
         if (fileExists('pom.xml')) {
           stage ('Maven Build') {
             container ('maven') {
+	      printTime("Starting maven build")
               def mvnCommand = "mvn -B"
               if (mavenSettingsConfigMap) {
                 mvnCommand += " --settings /msb_mvn_cfg/settings.xml"
               }
               mvnCommand += " ${mvnCommands}"
               sh mvnCommand
+	      printTime("Done Maven build")
             }
           }
         }
@@ -215,6 +224,7 @@ def call(body) {
           
           stage ('Docker Build') {
             container ('docker') {
+	      printTime("About to Docker build")
               imageTag = gitCommit
               def buildCommand = "docker build -t ${image}:${imageTag} "
               buildCommand += "--label org.label-schema.schema-version=\"1.0\" "
@@ -245,10 +255,14 @@ def call(body) {
                 sh "mkdir /home/jenkins/.docker"
                 sh "ln -s /msb_reg_sec/.dockerconfigjson /home/jenkins/.docker/config.json"
               }
+	      printTime("About to do build command")
               sh buildCommand
+	      printTime("Done the build command")
               if (registry) {
                 sh "docker tag ${image}:${imageTag} ${registry}${image}:${imageTag}"
+		printTime("Pushing to Docker registry")
                 sh "docker push ${registry}${image}:${imageTag}"
+		printTime("Done pushing to Docker registry")
               }
             }
           }
@@ -269,7 +283,8 @@ def call(body) {
 
       if (test && fileExists('pom.xml') && realChartFolder != null && fileExists(realChartFolder)) {
         stage ('Verify') {
-	        testsAttempted = true
+	  printTime("In verify stage")
+	  testsAttempted = true
           testNamespace = "testns-${env.BUILD_ID}-" + UUID.randomUUID()
           echo "testing against namespace " + testNamespace
           String tempHelmRelease = (image + "-" + testNamespace)
@@ -277,6 +292,7 @@ def call(body) {
           while (tempHelmRelease.endsWith('-') || tempHelmRelease.length() > 53) tempHelmRelease = tempHelmRelease.substring(0,tempHelmRelease.length()-1)
   
           container ('kubectl') {
+	   printTime("In kubectl container")
             def testNSCreationAttempt = sh(returnStatus: true, script: "kubectl create namespace ${testNamespace} > ns_creation_attempt.txt")
             if (testNSCreationAttempt != 0) {
               echo "Warning, did not create the test namespace successfully, error code is: ${testNSCreationAttempt}"		
@@ -293,12 +309,15 @@ def call(body) {
           }
 
           if (!helmInitialized) {
+	    printTime("Init helm")
             initalizeHelm ()
             helmInitialized = true
+	    printTime("Done with init helm")
           }
 	
           container ('helm') {
             echo "Attempting to deploy the test release"
+            printTime("About to Helm install as part of verify")
             def deployCommand = "helm install ${realChartFolder} --wait --set test=true --values pipeline.yaml --namespace ${testNamespace} --name ${tempHelmRelease}"
             if (fileExists("chart/overrides.yaml")) {
               deployCommand += " --values chart/overrides.yaml"
@@ -307,7 +326,9 @@ def call(body) {
               echo "Adding --tls to your deploy command"
               deployCommand += helmTlsOptions
             }
+	    printTime("About to deploy test release")
             testDeployAttempt = sh(script: "${deployCommand} > deploy_attempt.txt", returnStatus: true)
+	    printTime("Done deploying test release")
             if (testDeployAttempt != 0) {
               echo "Warning, did not deploy the test release into the test namespace successfully, error code is: ${testDeployAttempt}" 
               echo "This build will be marked as a failure: halting after the deletion of the test namespace."
@@ -317,18 +338,21 @@ def call(body) {
 
           container ('maven') {
             try {
-              // We have a test release that we can run our Maven tests on	    
+              // We have a test release that we can run our Maven tests on	
+	      printTime("In Maven container to run tests with")
               if (testDeployAttempt == 0) {
                 def mvnCommand = "mvn -B -Dnamespace.use.existing=${testNamespace} -Denv.init.enabled=false"
                 if (mavenSettingsConfigMap) {
                   mvnCommand += " --settings /msb_mvn_cfg/settings.xml"
                 }
-                mvnCommand += " verify"		  
+                mvnCommand += " verify"
+		printTime("About to verify")
                 verifyAttempt = sh(script: "${mvnCommand} > verify_attempt.txt", returnStatus: true)
                 if (verifyAttempt != 0) {
                   echo "Warning, did not run ${mvnCommand} successfully, error code is: ${verifyAttempt}"		
                 }
-              printFromFile("verify_attempt.txt")    
+		printTime("Done the verify")
+                printFromFile("verify_attempt.txt")    
               } else {
                 echo "Not running tests as we detected that your test release failed to deploy"
               }
@@ -339,25 +363,30 @@ def call(body) {
                 container ('kubectl') {
                   if (fileExists(realChartFolder)) {
                     container ('helm') {
+		      printTime("About to helm delete")
                       def deleteCommand = "helm delete ${tempHelmRelease} --purge"
                       if (helmSecret) {
                         echo "adding --tls"
                         deleteCommand += helmTlsOptions
                       }
                       // Until this is done, we can't get both stdout and the status code... https://issues.jenkins-ci.org/browse/JENKINS-44930?page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel&showAll=true
+		      printTime("About to delete test release")	    
                       def deletionAttempt = sh(script: "$deleteCommand > delete_test_release_attempt.txt", returnStatus: true)
                       if (deletionAttempt != 0) {
                         echo "Did not delete the test Helm release, error code from ${deleteCommand} is: ${deletionAttempt}" 
                       }
+		      printTime("Done attempting to delete test release")
                       printFromFile("delete_test_release_attempt.txt")
                     }
                   }
                   // Intentionally do this as the final step in here so we can actually delete it
                   // A namespace will not be removed if there's a Kube resource still active in there
+		  printTime("Attempting to delete test namespace")
                   def testNSDeletionAttempt = sh(script: "kubectl delete namespace ${testNamespace} > delete_test_namespace_attempt.txt", returnStatus: true)
                   if (testNSDeletionAttempt != 0) {
                     echo "Did not delete the test namespace ${testNamespace} successfully, error code is: ${testNSDeletionAttempt}" 
                   }
+		  printTime("Done attempting to delete test namespace")
                   printFromFile("delete_test_namespace_attempt.txt")
                 }                
               }
@@ -373,7 +402,10 @@ def call(body) {
            "imageTag=${imageTag}"
       
       sh "echo \"${result}\" > buildData.txt"
+	    
+      printTime("About to archive artifacts")
       archiveArtifacts 'buildData.txt'
+      printTime("Done archiving artifacts")
       // tests are enabled and yet something went wrong (e.g. didn't deploy the test release, or tests failed)? Fail the build
       
       echo "Test is " + test + ", tests attempted: " + testsAttempted
@@ -398,12 +430,21 @@ def call(body) {
           initalizeHelm ()
           helmInitialized = true
         }
-	      echo "Notifying Devops"
+	printTime("About to notify devops")
+	echo "Notifying Devops"
         notifyDevops(gitCommit, fullCommitID, registry + image, imageTag, 
           branchName, "build", projectName, projectNamespace, env.BUILD_NUMBER.toInteger())
+	printTime("Done notifying devops")
       }
     }
   }
+}
+
+def printTime(String message) {
+  println "Timing..."
+  println message
+  println ""
+  println new Date().format("ddMMyy.HHmm", TimeZone.getTimeZone('Europe/Amsterdam'))
 }
 
 def printFromFile(String fileName) {

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -251,9 +251,9 @@ def call(body) {
               }
               buildCommand += " ."
               if (registrySecret) {
-                sh "ln -s /msb_reg_sec/.dockercfg /home/jenkins/.dockercfg"
-                sh "mkdir /home/jenkins/.docker"
-                sh "ln -s /msb_reg_sec/.dockerconfigjson /home/jenkins/.docker/config.json"
+                sh "ln -s -f /msb_reg_sec/.dockercfg /home/jenkins/.dockercfg"
+                sh "mkdir -p /home/jenkins/.docker"
+                sh "ln -s -f /msb_reg_sec/.dockerconfigjson /home/jenkins/.docker/config.json"
               }
 	      printTime("About to do build command")
               sh buildCommand

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -175,7 +175,7 @@ def call(body) {
           stage ('Maven Build') {
             container ('maven') {
 	      printTime("Starting maven build")
-              def mvnCommand = "mvn -B"
+              def mvnCommand = "mvn -T 1C -B"
               if (mavenSettingsConfigMap) {
                 mvnCommand += " --settings /msb_mvn_cfg/settings.xml"
               }
@@ -341,7 +341,7 @@ def call(body) {
               // We have a test release that we can run our Maven tests on	
 	      printTime("In Maven container to run tests with")
               if (testDeployAttempt == 0) {
-                def mvnCommand = "mvn -B -Dnamespace.use.existing=${testNamespace} -Denv.init.enabled=false"
+                def mvnCommand = "mvn -T 1C -B -Dnamespace.use.existing=${testNamespace} -Denv.init.enabled=false"
                 if (mavenSettingsConfigMap) {
                   mvnCommand += " --settings /msb_mvn_cfg/settings.xml"
                 }

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -442,7 +442,7 @@ def call(body) {
 
 def printTime(String message) {
   time = new Date().format("ddMMyy.HHmm", TimeZone.getTimeZone('Europe/Amsterdam'))
-  println "Timing, $message: $date"
+  println "Timing, $message: $time"
 }
 
 def printFromFile(String fileName) {

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -441,7 +441,7 @@ def call(body) {
 }
 
 def printTime(String message) {
-  time = new Date().format("ddMMyy.HHmm", TimeZone.getTimeZone('Europe/Amsterdam'))
+  time = new Date().format("ddMMyy.HH:mm.ss", TimeZone.getTimeZone('Europe/Amsterdam'))
   println "Timing, $message: $time"
 }
 


### PR DESCRIPTION
Looks like the indenting's off here but it's not, view it raw [here](https://raw.githubusercontent.com/a-roberts/jenkins-library/timeit/vars/microserviceBuilderPipeline.groovy)

Four main changes

- want two Jenkins slaves and recycle the pods, after 60 minutes, get rid of them. Reduces init time, allows for caching

- mvn -T 1C = for each available thread, build. I've tested this works fine with https://github.com/IBMStockTrader/trader's microclimate branch

- force symlink as we're reusing the same slave and so its same workspace (so we get to keep around all of the already downloaded deps), same goes for `mkdir -p` as the directory may already exist from a previous run

- run in performance mode: don't write for each stage, no more atomic ops, pipeline won't be resumed from certain stage if jenkins dies though


For first time builds of a project, observed average time is between 7 and 11 minutes ((depending on how long it takes to find a slave without my changes)

With my changes this becomes 5 minutes on average.

I've observed 5min to < 2min build times for second runs due to the availability of mvn artifact reuse and git code reuse. 

I believe the tradeoffs are worth it and I've added plenty of instrumentation.

Here is my fastest observed complete run:

```
adams-mbp:microclimate-icp aroberts$ cat timeit.txt | grep Timing
Timing, In the pipeline: 061218.23:35.55
Timing, In the node microclimatePod code: 061218.23:35.55
Timing, In the extract stage: 061218.23:35.56
Timing, checkout scm done: 061218.23:35.58
Timing, Starting maven build: 061218.23:36.01
Timing, Done Maven build: 061218.23:36.14
Timing, About to Docker build: 061218.23:36.14
Timing, About to do build command: 061218.23:36.32
Timing, Done the build command: 061218.23:37.18
Timing, Pushing to Docker registry: 061218.23:37.23
Timing, Done pushing to Docker registry: 061218.23:37.29
Timing, About to archive artifacts: 061218.23:37.30
Timing, Done archiving artifacts: 061218.23:37.30
Timing, About to notify devops: 061218.23:37.35
Timing, Done notifying devops: 061218.23:37.35
```

This is compared to:
```
adams-mbp:microclimate-jenkins aroberts$ cat timingonly.txt | grep Timing
Timing, In the pipeline: 18:20.15
Timing, In the node microclimatePod code: 18:21.29
Timing, In the extract stage: 18:21.38
Timing, checkout scm done: 18:22.23
Timing, Starting maven build: 18:22.29
Timing, Done Maven build: 18:23.16
Timing, About to Docker build: 18:23.17
Timing, About to do build command: 18:23.35
Timing, Done the build command: 18:24.22
Timing, Pushing to Docker registry: 18:24.27
Timing, Done pushing to Docker registry: 18:24.34
Timing, About to archive artifacts: 18:24.36
Timing, Done archiving artifacts: 18:24.42
Timing, About to notify devops: 18:24.48
Timing, Done notifying devops: 18:24.49
```

Good resources on this:
- https://github.com/helm/charts/pull/6962/files for the retention policy
- https://hiya.com/blog/2017/10/02/kubernetes-base-jenkins-stateful-agents/
- https://github.com/jenkinsci/kubernetes-plugin

@mnuttall @dibbles PTAL. Not sure about the timezone part (I've used what's OK for me).