### PR TITLE
Remove experimental option on master, fork count 0 to prevent classloader bug

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -175,7 +175,7 @@ def call(body) {
           stage ('Maven Build') {
             container ('maven') {
 	      printTime("Starting maven build")
-              def mvnCommand = "mvn -T 1C -B"
+              def mvnCommand = "mvn -B"
               if (mavenSettingsConfigMap) {
                 mvnCommand += " --settings /msb_mvn_cfg/settings.xml"
               }
@@ -341,7 +341,7 @@ def call(body) {
               // We have a test release that we can run our Maven tests on	
 	      printTime("In Maven container to run tests with")
               if (testDeployAttempt == 0) {
-                def mvnCommand = "mvn -T 1C -B -Dnamespace.use.existing=${testNamespace} -Denv.init.enabled=false"
+                def mvnCommand = "mvn -B -Dnamespace.use.existing=${testNamespace} -Denv.init.enabled=false"
                 if (mavenSettingsConfigMap) {
                   mvnCommand += " --settings /msb_mvn_cfg/settings.xml"
                 }

--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -341,7 +341,7 @@ def call(body) {
               // We have a test release that we can run our Maven tests on	
 	      printTime("In Maven container to run tests with")
               if (testDeployAttempt == 0) {
-                def mvnCommand = "mvn -B -Dnamespace.use.existing=${testNamespace} -Denv.init.enabled=false"
+                def mvnCommand = "mvn -B -DforkCount=0 -Dnamespace.use.existing=${testNamespace} -Denv.init.enabled=false"
                 if (mavenSettingsConfigMap) {
                   mvnCommand += " --settings /msb_mvn_cfg/settings.xml"
                 }


### PR DESCRIPTION
The -T 1C option isn't guaranteed to always work so we should actually make it configurable instead (users shouldn't need to fork the library if they just want to turn it off).

The forkCount option prevents 

```
[INFO] Downloaded from central: https://repo.maven.apache.org/maven2/org/apache/maven/surefire/surefire-junit4/2.18.1/surefire-junit4-2.18.1.jar (68 kB at 412 kB/s)

-------------------------------------------------------
T E S T S
-------------------------------------------------------
Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter
```

which has been seen with the latest OpenJDK Docker images on ppc64le so far, with the version of the surefire plugin used by `mvn verify` (likely not restricted to this platform though).