### PR TITLE
Fork count 0 on the mvn verify

### DIFF
--- a/vars/microserviceBuilderPipeline.groovy
+++ b/vars/microserviceBuilderPipeline.groovy
@@ -341,7 +341,7 @@ def call(body) {
               // We have a test release that we can run our Maven tests on	
 	      printTime("In Maven container to run tests with")
               if (testDeployAttempt == 0) {
-                def mvnCommand = "mvn -B -Dnamespace.use.existing=${testNamespace} -Denv.init.enabled=false"
+                def mvnCommand = "mvn -B -DforkCount=0 -Dnamespace.use.existing=${testNamespace} -Denv.init.enabled=false"
                 if (mavenSettingsConfigMap) {
                   mvnCommand += " --settings /msb_mvn_cfg/settings.xml"
                 }


### PR DESCRIPTION
Same as https://github.com/microclimate-dev2ops/jenkins-library/pull/34 but on release branch

For more info see https://maven.apache.org/surefire/maven-surefire-plugin/examples/fork-options-and-parallel-execution.html and https://stackoverflow.com/questions/53010200/maven-surefire-could-not-find-forkedbooter-class/53128507